### PR TITLE
Spelling: no ..., …, Setting only available, Show notifications

### DIFF
--- a/data/ui/app-menu.glade
+++ b/data/ui/app-menu.glade
@@ -3,7 +3,7 @@
   <menu id="app-menu">
     <section>
       <item>
-	<attribute name="label" translatable="yes">Add Station...</attribute>
+	<attribute name="label" translatable="yes">Add Station</attribute>
 	<attribute name="action">app.add-station</attribute>
         <attribute name="accel">&lt;Primary&gt;a</attribute>
       </item>

--- a/data/ui/menubar.glade
+++ b/data/ui/menubar.glade
@@ -5,7 +5,7 @@
       <attribute name="label" translatable="yes">Menu</attribute>
       <section>
         <item>
-	  <attribute name="label" translatable="yes">Add Station...</attribute>
+	  <attribute name="label" translatable="yes">Add Station</attribute>
 	  <attribute name="action">app.add-station</attribute>
 	  <attribute name="accel">&lt;Primary&gt;a</attribute>
         </item>

--- a/data/ui/prefs-window.glade
+++ b/data/ui/prefs-window.glade
@@ -301,7 +301,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Emit Notifications</property>
+                        <property name="label" translatable="yes">Send Notifications</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>

--- a/data/ui/status-icon-menu.glade
+++ b/data/ui/status-icon-menu.glade
@@ -3,7 +3,7 @@
   <menu id="status-icon-menu">
     <section>
       <item>
-	<attribute name="label" translatable="yes">Add Station...</attribute>
+	<attribute name="label" translatable="yes">Add Station</attribute>
 	<attribute name="action">app.add-station</attribute>
       </item>
     </section>

--- a/src/core/gv-player.c
+++ b/src/core/gv-player.c
@@ -133,7 +133,7 @@ on_station_notify(GvStation *station,
 	g_assert(station == priv->station);
 
 	if (!g_strcmp0(property_name, "stream-uris")) {
-		DEBUG("Station %p: stream uris have changed", station);
+		DEBUG("Station %p: stream URIs have changed", station);
 
 		/* Check if there are some streams, and start playing if needed */
 		if (gv_station_get_stream_uris(station))
@@ -525,7 +525,7 @@ gv_player_set_station_by_uri(GvPlayer *self, const gchar *uri)
 	/* Look for the station in the station list */
 	station = gv_station_list_find_by_uri(priv->station_list, uri);
 	if (station == NULL) {
-		DEBUG("Station uri '%s' not found in station list", uri);
+		DEBUG("Station URI '%s' not found in station list", uri);
 		return FALSE;
 	}
 
@@ -703,11 +703,11 @@ gv_player_play(GvPlayer *self)
 	/* Get station data */
 	uris = gv_station_get_stream_uris(station);
 
-	/* If there's no uris, that probably means that the station uri
+	/* If there's no URIs, that probably means that the station URI
 	 * points to a playlist, and we need to download it.
 	 */
 	if (uris == NULL) {
-		/* Download the playlist that contains the stream uris */
+		/* Download the playlist that contains the stream URIs */
 		if (!gv_station_download_playlist(station))
 			WARNING("Can't download playlist");
 
@@ -801,22 +801,22 @@ gv_player_go(GvPlayer *self, const gchar *string_to_play)
 		return;
 	}
 
-	/* Otherwise, if it's a valid uri, try to play it */
+	/* Otherwise, if it's a valid URI, try to play it */
 	if (is_uri_scheme_supported(string_to_play)) {
 		GvStation *station;
 
 		station = gv_station_new(NULL, string_to_play);
 		gv_player_set_station(self, station);
 
-		INFO("'%s' is a valid uri, let's play", string_to_play);
+		INFO("'%s' is a valid URI, let's play", string_to_play);
 		gv_player_play(self);
 		return;
 	}
 
 	/* That looks like an invalid string then */
-	WARNING("'%s' is neither a known station or a valid uri", string_to_play);
+	WARNING("'%s' is neither a known station or a valid URI", string_to_play);
 	gv_errorable_emit_error(GV_ERRORABLE(self),
-	                        _("'%s' is neither a known station or a valid uri"),
+	                        _("'%s' is neither a known station or a valid URI"),
 	                        string_to_play);
 }
 
@@ -1014,7 +1014,7 @@ gv_player_class_init(GvPlayerClass *class)
 	                            GV_PARAM_DEFAULT_FLAGS | G_PARAM_READWRITE);
 
 	properties[PROP_STATION_URI] =
-	        g_param_spec_string("station-uri", "Current station uri",
+	        g_param_spec_string("station-uri", "Current station URI",
 	                            "This is used only to save the current station in conf",
 	                            NULL,
 	                            GV_PARAM_DEFAULT_FLAGS | G_PARAM_READWRITE);

--- a/src/ui/gv-main-window.c
+++ b/src/ui/gv-main-window.c
@@ -353,10 +353,10 @@ set_status_label(GtkLabel *label, GvPlayerState state, GvMetadata *metadata)
 			state_str = _("Playing");
 			break;
 		case GV_PLAYER_STATE_CONNECTING:
-			state_str = _("Connecting...");
+			state_str = _("Connecting…");
 			break;
 		case GV_PLAYER_STATE_BUFFERING:
-			state_str = _("Buffering...");
+			state_str = _("Buffering…");
 			break;
 		case GV_PLAYER_STATE_STOPPED:
 		default:

--- a/src/ui/gv-prefs-window.c
+++ b/src/ui/gv-prefs-window.c
@@ -480,7 +480,7 @@ gv_prefs_window_setup_widgets(GvPrefsWindow *self)
 		               priv->window_frame);
 	}
 
-	setup_feature(_("Emit notifications when the status changes."),
+	setup_feature(_("Show notification when the status changes."),
 	              priv->notif_enable_label,
 	              priv->notif_enable_switch,
 	              priv->notifications_feat);
@@ -509,7 +509,7 @@ gv_prefs_window_setup_widgets(GvPrefsWindow *self)
 		              status_icon_obj, "scroll-action",
 		              NULL, NULL);
 	} else {
-		setdown_widget(_("Seeting available only in status icon mode."),
+		setdown_widget(_("Setting only available in status icon mode."),
 		               priv->mouse_frame);
 	}
 


### PR DESCRIPTION
A lot of these are not in https://hosted.weblate.org/zen/goodvibes/translations, but that is another issue.

https://github.com/elboulangero/goodvibes/blob/9dfd7c19728c3beb573b11cf387bd0b1da17afea/src/ui/gv-prefs-window.c#L454
"Prevent the system from going to sleep while playing."

Possibly not consistent with

https://github.com/comradekingu/goodvibes/blob/4093849ef68bd4e6354278a0778b3749377f87cf/data/ui/prefs-window.glade#L138
"Prevent sleep while playing"

https://github.com/elboulangero/goodvibes/blob/9dfd7c19728c3beb573b11cf387bd0b1da17afea/data/ui/prefs-window.glade#L394
Display

as in?

https://github.com/elboulangero/goodvibes/blob/master/src/ui/gv-station-dialog.c#L426
Add new station

when others are "Add station", but next to "edit station", so maybe it makes sense.